### PR TITLE
fix(ci): pin Node 24 so CI npm ci matches lockfile (#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 24 / npm 11: lockfile was generated with npm 11; npm 10
+          # (Node 20/22) fails `npm ci` on optional @cloudflare/workers-types peers.
+          # Also matches wrangler/ai engines (>=22) and babel (^22.18 || >=24.11).
+          node-version: '24'
           cache: npm
       - run: npm ci
       # Root-only: `npm run lint` also lints ui/ and needs ui/node_modules.
@@ -30,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: ui/package-lock.json
       - run: npm ci

--- a/docs/guides/code-quality-automation.md
+++ b/docs/guides/code-quality-automation.md
@@ -1,6 +1,6 @@
 # Code Quality Automation — Implementation Guide
 
-**Current Status**: Complete (Phases 1–3). Tracked in [#40](https://github.com/SteveLeve/chatbot-demo-cloudflare/issues/40).
+**Current Status**: Phases 1–3 merged ([PR #42](https://github.com/SteveLeve/chatbot-demo-cloudflare/pull/42)). Post-merge: CI Node pin + lockfile/npm alignment in flight. Tracked in [#40](https://github.com/SteveLeve/chatbot-demo-cloudflare/issues/40).
 
 ## Overview
 
@@ -38,7 +38,14 @@ gh api repos/SteveLeve/chatbot-demo-cloudflare/rulesets
   - NO required status checks (CI is advisory until ruleset updated)
 ```
 
-Decision: ship CI without updating the ruleset to require the workflow (first PR only adds the check).
+Decision (at first merge): ship CI without updating the ruleset to require the workflow (first PR only adds the check).
+
+**Enforcement (2026-08-09):** keep **advisory** until CI is reliably green on `main`/PRs; then require `CI / root` + `CI / ui` on `protect-main`. Do not turn on required checks in this follow-up.
+
+### Post-merge CI fix (2026-08-09)
+
+- Merge push CI failed: `npm ci` under Node 20 / npm 10 reported `Missing: @cloudflare/workers-types@4.20260702.1` (optional peer; lockfile written with npm 11).
+- Fix: pin workflow to **Node 24** (npm 11) and set `package.json` `engines.node` to `>=24.11.0`.
 
 ## Pre-commit timing (measured 2026-08-09)
 
@@ -74,7 +81,7 @@ Root `.lintstagedrc.json` and `ui/.lintstagedrc.json` — lint-staged picks near
 
 ### Phase 3 — CI workflow
 
-`.github/workflows/ci.yml`:
+`.github/workflows/ci.yml` (Node **24**):
 
 - **root**: `npm ci` → `npx eslint .` → typecheck → `npm test -- --run` (not `npm run lint` — that also hits `ui/` and needs a separate install)
 - **ui**: `npm ci` → lint → build (`ui/.npmrc` applies in CI)

--- a/docs/status/now-next.md
+++ b/docs/status/now-next.md
@@ -1,28 +1,31 @@
 # Status: Now & Next
-- **Last Updated**: 2026-08-08
+
+- **Last Updated**: 2026-08-09
 - **Owner**: Project Maintainer
 
 ## Now
-- Phase 1 docs pivot **merged** (PR #31).
-- Rework cutover **merged** (PR #37): archived `production-readiness.md`, deleted dead `QueryInterface.tsx`.
-- Phase 0 model refresh **merged** (PR #38): `@cf/meta/llama-4-scout-17b-16e-instruct`; IDs in `src/config/models.ts`.
-- Phase 2 corpus + glossary **merged** (PR #39): curated `data/corpus/`, static manifest, corpus browser, glossary prompt injection.
-- **Phase 3 (#34) in flight** (`feat/34-agent-do-trace`): Agents SDK `RAGAgent`, trace panel, `durable_objects` bindings.
-- Prior hardening remains shipped: security (PRs #22/#23), perf (#28), observability phase 1 (#29).
+
+- Phase 3 Agents SDK / trace UI **merged** (PR #41 / #34).
+- Code quality automation Phases 1–3 **merged** (PR #42 / #40): ESLint, Prettier, Husky+lint-staged, CI.
+- **Follow-up (#40)**: pin CI to Node 24 so `npm ci` matches the npm 11 lockfile. Ruleset stays **advisory** until CI is reliably green, then enforce.
+- Prior hardening remains shipped: security (PRs #22/#23), perf (#28), observability phase 1 (#29); model refresh (#38), corpus (#39).
 
 ## Next
-- Merge Phase 3 (#34), then open phase branches in order:
+
+- Close out #40 post-merge CI fix, then open phase branches in order:
   - Phase 4 (#35): eval reporting. Phase 5 (#36): red-team demo mode.
 - Deprioritized vs reimagining: OTLP dashboards (#18).
 - **Coupled to Phase 5**: privacy endpoints (#19).
 
 ## Risks/Watch
+
 - Escape hatch: evaluate runbook criteria 1–8 at each phase start/merge (`docs/runbooks/rework-branch-cutover.md`). Cutover gate: **passed**.
 - Durable Objects configured in Phase 3 (#34) — `RAGAgent` SQLite-backed DO + trace panel.
 - Scope creep into unbounded corpus or third-party agent orchestration frameworks — enforce #30 non-goals.
 - Rate limiting false positives during peak demo traffic — monitor logs.
 
 ## References
+
 - Epic: #30 — sub-issues #32 (Phase 0), #33 (Phase 2), #34 (Phase 3), #35 (Phase 4), #36 (Phase 5)
 - Spec: `docs/spec/spec-agentic-rag-portfolio.md`
 - ADR: `docs/decisions/adr-20260807-agents-sdk-runtime.md`

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Cloudflare-first agentic RAG portfolio demo — Agents SDK, Workers AI, Vectorize, D1, R2 (epic #30; pivoting from an earlier single-turn RAG demo)",
   "type": "module",
   "main": "src/index.ts",
+  "engines": {
+    "node": ">=24.11.0"
+  },
   "scripts": {
     "dev": "wrangler dev",
     "build": "npm run corpus:build && cd ui && npm run build",


### PR DESCRIPTION
## Summary
- Pin CI (`root` + `ui`) to Node 24 so `npm ci` uses npm 11, matching the lockfile written after #42
- Set `engines.node` to `>=24.11.0` and document the post-merge failure + **advisory** ruleset stance in the code-quality guide / now-next
- Closes the immediate #40 follow-up; enforcement of required status checks stays deferred until CI is reliably green

## Test plan
- [ ] CI `root` job: `npm ci` succeeds under Node 24
- [ ] CI `root`: eslint, typecheck, tests pass
- [ ] CI `ui`: lint + build pass
- [ ] Confirm `protect-main` still has no required status checks (advisory)


Made with [Cursor](https://cursor.com)