### PR TITLE
docs: record #40 CI enforcement on protect-main

### DIFF
--- a/docs/guides/code-quality-automation.md
+++ b/docs/guides/code-quality-automation.md
@@ -1,18 +1,19 @@
 # Code Quality Automation — Implementation Guide
 
-**Current Status**: Phases 1–3 merged ([PR #42](https://github.com/SteveLeve/chatbot-demo-cloudflare/pull/42)). Post-merge: CI Node pin + lockfile/npm alignment in flight. Tracked in [#40](https://github.com/SteveLeve/chatbot-demo-cloudflare/issues/40).
+**Current Status**: Complete (Phases 1–4). Tracked in [#40](https://github.com/SteveLeve/chatbot-demo-cloudflare/issues/40).
 
 ## Overview
 
-Mechanical quality gates for this single-Worker + Vite-UI repo: ESLint, Prettier, a pre-commit hook, and a CI workflow. Does **not** include Semgrep, dependency-graph analysis, or coverage gates — see [Explicitly out of scope](#explicitly-out-of-scope).
+Mechanical quality gates for this single-Worker + Vite-UI repo: ESLint, Prettier, a pre-commit hook, CI, and required status checks on `main`. Does **not** include Semgrep, dependency-graph analysis, or coverage gates — see [Explicitly out of scope](#explicitly-out-of-scope).
 
 ## What landed
 
-| Phase                         | Status | Artifacts                                                                                 |
-| ----------------------------- | ------ | ----------------------------------------------------------------------------------------- |
-| 1 — Lint + format + typecheck | Done   | `eslint.config.js`, `ui/eslint.config.js`, `.prettierrc`, `.prettierignore`, root scripts |
-| 2 — Pre-commit                | Done   | Husky, lint-staged, split `.lintstagedrc.json` (root + `ui/`)                             |
-| 3 — CI                        | Done   | `.github/workflows/ci.yml`                                                                |
+| Phase                         | Status | Artifacts                                                                                                                          |
+| ----------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1 — Lint + format + typecheck | Done   | `eslint.config.js`, `ui/eslint.config.js`, `.prettierrc`, `.prettierignore`, root scripts                                          |
+| 2 — Pre-commit                | Done   | Husky, lint-staged, split `.lintstagedrc.json` (root + `ui/`)                                                                      |
+| 3 — CI                        | Done   | `.github/workflows/ci.yml` (Node 24); green on `main` after [PR #43](https://github.com/SteveLeve/chatbot-demo-cloudflare/pull/43) |
+| 4 — Enforce on merge          | Done   | `protect-main` ruleset requires status checks `root` + `ui`                                                                        |
 
 **Formatting policy**: incremental — Prettier runs on staged files via pre-commit, not a repo-wide format commit. `npm run format:check` may fail on untouched files until they are edited.
 
@@ -26,7 +27,9 @@ npm test -- --run  # exits 0 — vitest single pass (CI sets CI=true)
 
 Pre-commit: stage a misformatted file → `git commit` auto-fixes via lint-staged.
 
-## Branch protection (recorded 2026-08-09)
+## Branch protection / ruleset
+
+### Snapshot before enforcement (2026-08-09)
 
 ```text
 gh api repos/SteveLeve/chatbot-demo-cloudflare/branches/main/protection
@@ -35,17 +38,29 @@ gh api repos/SteveLeve/chatbot-demo-cloudflare/branches/main/protection
 gh api repos/SteveLeve/chatbot-demo-cloudflare/rulesets
 → active ruleset "protect-main" (id 11921368):
   - required PR, linear history, code-owner review, squash merge
-  - NO required status checks (CI is advisory until ruleset updated)
+  - NO required status checks (CI advisory)
 ```
 
-Decision (at first merge): ship CI without updating the ruleset to require the workflow (first PR only adds the check).
+Decision at first merge ([PR #42](https://github.com/SteveLeve/chatbot-demo-cloudflare/pull/42)): ship CI without requiring checks so the workflow could appear on `main`.
 
-**Enforcement (2026-08-09):** keep **advisory** until CI is reliably green on `main`/PRs; then require `CI / root` + `CI / ui` on `protect-main`. Do not turn on required checks in this follow-up.
-
-### Post-merge CI fix (2026-08-09)
+### Post-merge CI fix (2026-08-09 / [PR #43](https://github.com/SteveLeve/chatbot-demo-cloudflare/pull/43))
 
 - Merge push CI failed: `npm ci` under Node 20 / npm 10 reported `Missing: @cloudflare/workers-types@4.20260702.1` (optional peer; lockfile written with npm 11).
 - Fix: pin workflow to **Node 24** (npm 11) and set `package.json` `engines.node` to `>=24.11.0`.
+- CI on `main` green: [run 31348577919](https://github.com/SteveLeve/chatbot-demo-cloudflare/actions/runs/31348577919).
+
+### Enforcement (2026-08-09)
+
+`protect-main` (id 11921368) now includes:
+
+```text
+required_status_checks:
+  - context: root
+  - context: ui
+  strict_required_status_checks_policy: true
+```
+
+Job contexts match `.github/workflows/ci.yml` job names (`root`, `ui`). Existing PR / linear-history / code-owner / squash rules unchanged.
 
 ## Pre-commit timing (measured 2026-08-09)
 
@@ -88,15 +103,20 @@ Root `.lintstagedrc.json` and `ui/.lintstagedrc.json` — lint-staged picks near
 
 No `format:check` in CI (incremental formatting).
 
+### Phase 4 — Enforce CI on merge
+
+Required status checks on `protect-main` so PRs cannot merge to `main` unless `root` and `ui` succeed on the latest head (`strict_required_status_checks_policy: true`).
+
 ## Explicitly out of scope
 
 - Security scanning (Semgrep)
 - Dependency-graph analysis (dependency-cruiser / knip)
 - Coverage gates (`test:coverage` still broken)
-- Ruleset update to require CI status check (deferred)
 - `CONTRIBUTING.md`
 
 ## References
 
 - [Issue #40](https://github.com/SteveLeve/chatbot-demo-cloudflare/issues/40)
+- [PR #42](https://github.com/SteveLeve/chatbot-demo-cloudflare/pull/42) — Phases 1–3
+- [PR #43](https://github.com/SteveLeve/chatbot-demo-cloudflare/pull/43) — Node 24 CI pin
 - [`docs/status/now-next.md`](../status/now-next.md)

--- a/docs/status/now-next.md
+++ b/docs/status/now-next.md
@@ -6,13 +6,12 @@
 ## Now
 
 - Phase 3 Agents SDK / trace UI **merged** (PR #41 / #34).
-- Code quality automation Phases 1–3 **merged** (PR #42 / #40): ESLint, Prettier, Husky+lint-staged, CI.
-- **Follow-up (#40)**: pin CI to Node 24 so `npm ci` matches the npm 11 lockfile. Ruleset stays **advisory** until CI is reliably green, then enforce.
+- Code quality automation **complete** (#40): Phases 1–3 (PR #42), Node 24 CI pin (PR #43), `protect-main` requires `root` + `ui`.
 - Prior hardening remains shipped: security (PRs #22/#23), perf (#28), observability phase 1 (#29); model refresh (#38), corpus (#39).
 
 ## Next
 
-- Close out #40 post-merge CI fix, then open phase branches in order:
+- Open epic #30 phase branches in order:
   - Phase 4 (#35): eval reporting. Phase 5 (#36): red-team demo mode.
 - Deprioritized vs reimagining: OTLP dashboards (#18).
 - **Coupled to Phase 5**: privacy endpoints (#19).


### PR DESCRIPTION
## Summary
- Record Phase 4 of [#40](https://github.com/SteveLeve/chatbot-demo-cloudflare/issues/40): `protect-main` now requires status checks `root` + `ui` (strict)
- Mark code-quality automation complete in the guide and `docs/status/now-next.md`

## Test plan
- [ ] Confirm ruleset shows required checks: `gh api repos/SteveLeve/chatbot-demo-cloudflare/rulesets/11921368`
- [ ] Docs render correctly on GitHub

Closes #40


Made with [Cursor](https://cursor.com)